### PR TITLE
Update Supervisely SDK to 6.73.564

### DIFF
--- a/config.json
+++ b/config.json
@@ -4,7 +4,7 @@
   "version": "2.0.0",
   "categories": ["images", "collaboration", "export"],
   "description": "Download activity as csv file",
-  "docker_image": "supervisely/collaboration:6.73.564",
+  "docker_image": "supervisely/base-py-sdk-hardened:6.73.564",
   "instance_version": "6.15.60",
   "main_script": "src/main.py",
   "task_location": "workspace_tasks",

--- a/config.json
+++ b/config.json
@@ -5,7 +5,7 @@
   "categories": ["images", "collaboration", "export"],
   "description": "Download activity as csv file",
   "docker_image": "supervisely/collaboration:6.73.564",
-  "instance_version": "6.10.0",
+  "instance_version": "6.15.60",
   "main_script": "src/main.py",
   "task_location": "workspace_tasks",
   "icon": "https://i.imgur.com/pJEJ5zP.png",

--- a/config.json
+++ b/config.json
@@ -4,7 +4,7 @@
   "version": "2.0.0",
   "categories": ["images", "collaboration", "export"],
   "description": "Download activity as csv file",
-  "docker_image": "supervisely/collaboration:6.73.157",
+  "docker_image": "supervisely/collaboration:6.73.564",
   "instance_version": "6.10.0",
   "main_script": "src/main.py",
   "task_location": "workspace_tasks",

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,1 +1,1 @@
-supervisely==6.73.157
+supervisely==6.73.564


### PR DESCRIPTION
Updates default Supervisely Docker apps to Supervisely SDK `6.73.564`.

- Updates `docker_image` tags for default Supervisely images.
- Updates Supervisely SDK references in requirements and Dockerfiles.
- Does not release applications.

Validation: generated ecosystem inventory report.
